### PR TITLE
spherical harmonic SN3D normalization

### DIFF
--- a/getRSH.m
+++ b/getRSH.m
@@ -25,7 +25,7 @@ dirs = dirs_deg*pi/180;
 % initialize SH matrix
 R_N = zeros(Nharm, Ndirs);
 % zero order
-R_N(1,:) = 1/sqrt(4*pi);
+R_N(1,:) = 1;
 % higher orders
 if N>0 
     idx_R = 1;
@@ -40,7 +40,7 @@ if N>0
         Pnm = uncondon .* [Pnm(end:-1:2, :); Pnm];
         
         % normalisations
-        norm_real = sqrt( (2*n+1)*factorial(n-m) ./ (4*pi*factorial(n+m)) );
+        norm_real = sqrt( (2*n+1)*factorial(n-m) ./ factorial(n+m) );
         
         % convert to matrix, for direct matrix multiplication with the rest
         Nnm = norm_real * ones(1,Ndirs);
@@ -51,7 +51,7 @@ if N>0
         CosSin(n+1,:) = ones(1,size(dirs,1));
         % positive and negative degrees
         CosSin(m(2:end)+n+1,:) = sqrt(2)*cos(m(2:end)*dirs(:,1)');
-        CosSin(-m(end:-1:2)+n+1,:) = sqrt(2)*sin(m(end:-1:2)*dirs(:,1)');
+        CosSin(-m(end:-1:2)+n+1,:) = - sqrt(2)*sin(m(end:-1:2)*dirs(:,1)');
         Rnm = Nnm .* Pnm .* CosSin;
         
         R_N(idx_R + (1:2*n+1), :) = Rnm;


### PR DESCRIPTION
Comparing the encoding gains produced by ```getRSH.m``` against 2 other libraries (namely [Ambix](https://github.com/kronihias/ambix) and the [SPAT](http://forumnet.ircam.fr/product/spat-en/)): they matched assuming hereafter modification (N3D normalization, summed diff. between 3rd order gains, for any point on the sphere below ~10-6).

*Did not (yet) took a proper look at "why" in the equations. May be completely off-topic, e.g. different normalization scheme in this lib. Ignore if so.*